### PR TITLE
[DLS-9174] contact person tpl autofill

### DIFF
--- a/app/uk/gov/hmrc/fhregistrationfrontend/forms/mappings/Mappings.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/forms/mappings/Mappings.scala
@@ -41,13 +41,13 @@ object Mappings {
 
   def address: Mapping[Address] =
     mapping(
-      "Line1" -> addressLine,
-      "Line2" -> optional(addressLine),
-      "Line3" -> optional(addressLine),
-      "Line4" -> optional(addressLine),
-      "postcode" -> postcode,
+      "Line1"       -> addressLine,
+      "Line2"       -> optional(addressLine),
+      "Line3"       -> optional(addressLine),
+      "Line4"       -> optional(addressLine),
+      "postcode"    -> postcode,
       "countryCode" -> optional(nonEmptyText),
-      "lookupId" -> optional(text).transform(_ filterNot StringUtils.isBlank, (v: Option[String]) => v)
+      "lookupId"    -> optional(text).transform(_ filterNot StringUtils.isBlank, (v: Option[String]) => v)
     )(Address.apply)(Address.unapply)
 
   def postcode: Mapping[String] =
@@ -69,12 +69,12 @@ object Mappings {
   def email: Mapping[String] = nonEmptyText(0, 100) verifying Constraints.emailAddress
 
   def companyRegistrationNumber =
-    nonEmptyText transform(value => value.replaceAll("\\s", ""), { v: String =>
+    nonEmptyText transform (value => value.replaceAll("\\s", ""), { v: String =>
       v
     }) verifying Constraints.pattern("^[a-zA-Z0-9]{8}$".r)
 
   def companyRegistrationNumberFormatted =
-    nonEmptyText transform(value => value.trim, { v: String =>
+    nonEmptyText transform (value => value.trim, { v: String =>
       v
     })
 
@@ -120,16 +120,16 @@ object Mappings {
 
   def alternativeEmail: Mapping[AlternativeEmail] =
     mapping(
-      "email" -> email,
+      "email"             -> email,
       "emailConfirmation" -> of(emailConfirmationFormat)
     )(AlternativeEmail.apply)(AlternativeEmail.unapply)
 
   def internationalAddress: Mapping[InternationalAddress] =
     mapping(
-      "Line1" -> addressLine,
-      "Line2" -> optional(addressLine),
-      "Line3" -> optional(addressLine),
-      "Line4" -> addressLine,
+      "Line1"       -> addressLine,
+      "Line2"       -> optional(addressLine),
+      "Line3"       -> optional(addressLine),
+      "Line4"       -> addressLine,
       "countryCode" -> nonEmptyText
     )(InternationalAddress.apply)(InternationalAddress.unapply)
 
@@ -146,19 +146,19 @@ object Mappings {
 
   private val allDateValuesEntered: RawFormValues => ValidationResult = {
     case ("", "", "") => invalid("date.empty.error")
-    case ("", "", _) => invalid("day-and-month.missing")
-    case (_, "", "") => invalid("month-and-year.missing")
-    case ("", _, "") => invalid("day-and-year.missing")
-    case ("", _, _) => invalid("day.missing")
-    case (_, "", _) => invalid("month.missing")
-    case (_, _, "") => invalid("year.missing")
-    case _ => Valid
+    case ("", "", _)  => invalid("day-and-month.missing")
+    case (_, "", "")  => invalid("month-and-year.missing")
+    case ("", _, "")  => invalid("day-and-year.missing")
+    case ("", _, _)   => invalid("day.missing")
+    case (_, "", _)   => invalid("month.missing")
+    case (_, _, "")   => invalid("year.missing")
+    case _            => Valid
   }
 
   private val dateIsValid: RawFormValues => ValidationResult = {
-    case (d, m, y) if Try(s"$d$m$y".toInt).isFailure => invalid("date.error.invalid")
+    case (d, m, y) if Try(s"$d$m$y".toInt).isFailure         => invalid("date.error.invalid")
     case (d, m, y) if localDateFromValues(d, m, y).isFailure => invalid("date.error.invalid")
-    case _ => Valid
+    case _                                                   => Valid
   }
 
   private val dateInAllowedRange: RawFormValues => ValidationResult = {
@@ -176,9 +176,9 @@ object Mappings {
 
   def localNew =
     tuple(
-      "day" -> text,
+      "day"   -> text,
       "month" -> text,
-      "year" -> text
+      "year"  -> text
     ).transform({ case (d, m, y) => (d.trim, m.trim, y.trim) }, { v: RawFormValues =>
         v
       })
@@ -192,10 +192,10 @@ object Mappings {
 
   def localDate =
     tuple(
-      "day" -> number(min = 1, max = 31),
+      "day"   -> number(min = 1, max = 31),
       "month" -> number(min = 1, max = 12),
-      "year" -> number(min = 1800, max = 2999)
-    ) verifying("error.invalid", x => localDateTimeConstraint(x)) transform(
+      "year"  -> number(min = 1800, max = 2999)
+    ) verifying ("error.invalid", x => localDateTimeConstraint(x)) transform (
       x => localDateTime(x),
       (d: LocalDate) => (d.getDayOfMonth, d.getMonth.getValue, d.getYear)
     )
@@ -209,12 +209,12 @@ object Mappings {
   def oneOf(options: Seq[String]) = nonEmptyText verifying oneOfConstraint(options)
 
   def `enum`[E <: Enumeration](
-                                `enum`: E,
-                                requiredErrorKey: String = "error.required",
-                                args: Seq[String] = Nil): Mapping[E#Value] = of(enumFormat(`enum`, requiredErrorKey, args))
+    `enum`: E,
+    requiredErrorKey: String = "error.required",
+    args: Seq[String] = Nil): Mapping[E#Value] = of(enumFormat(`enum`, requiredErrorKey, args))
 
   def optionalWithYesOrNo[T](wrapped: Mapping[T]): Mapping[Option[T]] =
-    x(wrapped) verifying("error.invalid", y) transform(z, t)
+    x(wrapped) verifying ("error.invalid", y) transform (z, t)
 
   def string(errorKey: String = "error.required", args: Seq[String] = Seq.empty): FieldMapping[String] =
     of(stringFormatter(errorKey, args))
@@ -226,8 +226,8 @@ object Mappings {
 
   private def y[T]: ((Boolean, Option[T])) => Boolean = {
     case (true, Some(_)) => true
-    case (false, None) => true
-    case _ => false
+    case (false, None)   => true
+    case _               => false
   }
 
   private def z[T]: ((Boolean, Option[T])) => Option[T] = {

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/businessPartners/v2/business_partners_enter_company_name.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/businessPartners/v2/business_partners_enter_company_name.scala.html
@@ -64,7 +64,7 @@
                 errorMessage = form(formKey).error.map{ e =>
                     ErrorMessage(
                         content = Text(Messages(s"fh.businessPartners.${e.key}.${e.message}")),
-                        visuallyHiddenText = Some(Messages("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(Messages("generic.errorPrefix"))
                     )
                 }
             )

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/businessPartners/v2/business_partners_enter_company_registration_number.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/businessPartners/v2/business_partners_enter_company_registration_number.scala.html
@@ -74,7 +74,7 @@
                 errorMessage = regNumberForm(companyRegistrationNumberKey).error.map{ e =>
                     ErrorMessage(
                         content = Text(Messages(s"fh.businessPartners.${e.key}.${e.message}")),
-                        visuallyHiddenText = Some(Messages("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(Messages("generic.errorPrefix"))
                     )
                 }
             )

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/businessPartners/v2/business_partners_name.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/businessPartners/v2/business_partners_name.scala.html
@@ -58,7 +58,7 @@
             errorMessage = form(formKey).error.map { e =>
                 ErrorMessage(
                     content = Text(Messages(s"fh.businessPartners.${e.key}.${e.message}")),
-                    visuallyHiddenText = Some(Messages("fh.generic.errorPrefix"))
+                    visuallyHiddenText = Some(Messages("generic.errorPrefix"))
                 )
             }
         ))

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/contact_person.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/contact_person.scala.html
@@ -189,6 +189,7 @@ autocompleteJavascript: HmrcAccessibleAutocompleteJavascript)
                     content = HtmlContent(s"<strong>${messages("fh.contact_person.job_title.label")}</strong>")
                 ),
                 classes = "govuk-!-width-one-half",
+                autocomplete = Some("organization-title"),
                 value = contactPersonForm(jobTitleKey).value,
                 errorMessage = contactPersonForm(jobTitleKey).error.map{ e =>
                     ErrorMessage(

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/contact_person.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/contact_person.scala.html
@@ -155,7 +155,7 @@ autocompleteJavascript: HmrcAccessibleAutocompleteJavascript)
                 errorMessage = contactPersonForm(firstNameKey).error.map{ e =>
                     ErrorMessage(
                         content = Text(messages(s"fh.contact_person.$firstNameKey.${e.message}")),
-                        visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(messages("generic.errorPrefix"))
                     )
                 }
             ))
@@ -175,7 +175,7 @@ autocompleteJavascript: HmrcAccessibleAutocompleteJavascript)
                 errorMessage = contactPersonForm(lastNameKey).error.map{ e =>
                     ErrorMessage(
                         content = Text(messages(s"fh.contact_person.$lastNameKey.${e.message}")),
-                        visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(messages("generic.errorPrefix"))
                     )
                 }
             ))
@@ -193,7 +193,7 @@ autocompleteJavascript: HmrcAccessibleAutocompleteJavascript)
                 errorMessage = contactPersonForm(jobTitleKey).error.map{ e =>
                     ErrorMessage(
                         content = Text(messages(s"fh.contact_person.$jobTitleKey.${e.message}")),
-                        visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(messages("generic.errorPrefix"))
                     )
                 }
             ))
@@ -213,7 +213,7 @@ autocompleteJavascript: HmrcAccessibleAutocompleteJavascript)
                 errorMessage = contactPersonForm(telephoneKey).error.map{ e =>
                     ErrorMessage(
                         content = Text(messages(s"fh.contact_person.$telephoneKey.${e.message}")),
-                        visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(messages("generic.errorPrefix"))
                     )
                 }
             ))

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/forms/contact_person.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/forms/contact_person.scala.html
@@ -162,7 +162,7 @@
         contactPersonForm(firstNameKey).error.map{ e =>
           ErrorMessage(
             content = Text(messages(s"fh.contact_person.$firstNameKey.${e.message}")),
-            visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+            visuallyHiddenText = Some(messages("generic.errorPrefix"))
           )
         }
     ))
@@ -183,7 +183,7 @@
         contactPersonForm(lastNameKey).error.map{ e =>
           ErrorMessage(
             content = Text(messages(s"fh.contact_person.$lastNameKey.${e.message}")),
-            visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+            visuallyHiddenText = Some(messages("generic.errorPrefix"))
           )
         }
     ))
@@ -202,7 +202,7 @@
         contactPersonForm(jobTitleKey).error.map{ e =>
           ErrorMessage(
             content = Text(messages(s"fh.contact_person.$jobTitleKey.${e.message}")),
-            visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+            visuallyHiddenText = Some(messages("generic.errorPrefix"))
           )
         }
     ))
@@ -223,7 +223,7 @@
         contactPersonForm(telephoneKey).error.map{ e =>
           ErrorMessage(
             content = Text(messages(s"fh.contact_person.$telephoneKey.${e.message}")),
-            visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+            visuallyHiddenText = Some(messages("generic.errorPrefix"))
           )
         }
     ))

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/AddressInternational.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/AddressInternational.scala.html
@@ -46,7 +46,7 @@
             formDate(s"$fieldName.Line1").error.map{ e =>
                 ErrorMessage(
                     content = Text(message(s"fh.contact_person.$fieldName.Line1.${e.message}")),
-                    visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                    visuallyHiddenText = Some(message("generic.errorPrefix"))
                 )
             }
     ))
@@ -67,7 +67,7 @@
             formDate(s"$fieldName.Line2").error.map{ e =>
                 ErrorMessage(
                     content = Text(message(s"fh.contact_person.$fieldName.Line2.${e.message}")),
-                    visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                    visuallyHiddenText = Some(message("generic.errorPrefix"))
                 )
             }
     ))
@@ -87,7 +87,7 @@
             formDate(s"$fieldName.Line3").error.map{ e =>
                 ErrorMessage(
                     content = Text(message(s"fh.contact_person.$fieldName.Line3.${e.message}")),
-                    visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                    visuallyHiddenText = Some(message("generic.errorPrefix"))
                 )
             }
     ))

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/AddressUK.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/AddressUK.scala.html
@@ -48,7 +48,7 @@
                     formDate(s"$fieldName.Line1").error.map{ e =>
                     ErrorMessage(
                         content = if(formName.isDefined) Text(message(s"fh.${formName.get}.$fieldName.Line1.${e.message}")) else Text(message(s"fh.$fieldName.Line1.${e.message}")),
-                        visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(message("generic.errorPrefix"))
                     )
                 }
         ))
@@ -69,7 +69,7 @@
                 formDate(s"$fieldName.Line2").error.map{ e =>
                     ErrorMessage(
                         content = if(formName.isDefined) Text(message(s"fh.${formName.get}.$fieldName.Line2.${e.message}")) else Text(message(s"fh.$fieldName.Line2.${e.message}")),
-                        visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(message("generic.errorPrefix"))
                     )
                 }
         ))
@@ -89,7 +89,7 @@
                 formDate(s"$fieldName.Line3").error.map{ e =>
                     ErrorMessage(
                         content = if(formName.isDefined) Text(message(s"fh.${formName.get}.$fieldName.Line3.${e.message}")) else Text(message(s"fh.$fieldName.Line3.${e.message}")),
-                        visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(message("generic.errorPrefix"))
                     )
                 }
         ))
@@ -109,7 +109,7 @@
                 formDate(s"$fieldName.Line4").error.map{ e =>
                     ErrorMessage(
                         content = if(formName.isDefined) Text(message(s"fh.${formName.get}.$fieldName.Line4.${e.message}")) else Text(message(s"fh.$fieldName.Line4.${e.message}")),
-                        visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(message("generic.errorPrefix"))
                     )
                 }
         ))
@@ -130,7 +130,7 @@
                 formDate(s"$fieldName.postcode").error.map{ e =>
                     ErrorMessage(
                         content = if(formName.isDefined) Text(message(s"fh.${formName.get}.$fieldName.postcode.${e.message}")) else Text(message(s"fh.$fieldName.postcode.${e.message}")),
-                        visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+                        visuallyHiddenText = Some(message("generic.errorPrefix"))
                     )
                 }
         ))

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/CountryCodes.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/CountryCodes.scala.html
@@ -58,7 +58,7 @@
     name = countryCodeName,
     errorMessage = if(params.hasErrors) Some(ErrorMessage(
         content = Text(params.error),
-        visuallyHiddenText = Some(message("fh.generic.errorPrefix"))
+        visuallyHiddenText = Some(message("generic.errorPrefix"))
     )) else None,
     classes = "govuk-!-width-three-quarters",
     items = Seq(

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/company_officers/inputText.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/company_officers/inputText.scala.html
@@ -43,7 +43,7 @@
                 ErrorMessage(
                     content = Text(messages(s"fh.${e.key}.${e.message}", section)
                 ),
-                    visuallyHiddenText = Some(messages("fh.generic.errorPrefix"))
+                    visuallyHiddenText = Some(messages("generic.errorPrefix"))
                 )
             },
         value = companyOfficersForm(identificationKey).value


### PR DESCRIPTION
In addition to adding the missing autocomplete to "Job title" I'm also fixing the use of the wrong error prefix key in this form, the key used is the one used elsewhere for the page title prefix which produces a colon, but inline ErrorMessage add the colon also, this renders double colons - updating to use the generic.errorPrefix key as elsewhere and this fixes it.