### PR TITLE
DLS-9188 - Multiple h1 on page error summary in wrong place

### DIFF
--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/emailverification/email_edit.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/emailverification/email_edit.scala.html
@@ -41,21 +41,25 @@
 
 @layout(title = titlePrefix + title, Some(pageScripts)) {
 
+    @if(emailVerificationForm.errors.nonEmpty) {
+
+        @viewHelpers.govukErrorSummary(ErrorSummary(errorList =
+            Seq(ErrorLink(
+                href = Some(s"${emailVerificationForm.errors.head.key}"),
+                content = Text(messages(s"fh.${emailVerificationForm.errors.head.key}.${emailVerificationForm.
+                        errors.head.message}"))
+            )),
+            title = Text(messages("fh.generic.error"))
+        ))
+    }
+
     <h1 class="govuk-heading-l">@title</h1>
 
+    @viewHelpers.govukInsetText(InsetText(
+        content = Text(Messages("fh.emailVerification.alternativeEmail.info"))
+    ))
+
     @viewHelpers.form(action = uk.gov.hmrc.fhregistrationfrontend.controllers.routes.EmailVerificationController.submitContactEmail, Symbol("novalidate") -> "novalidate") {
-        @if(emailVerificationForm.errors.nonEmpty) {
-
-            @viewHelpers.govukErrorSummary(ErrorSummary(errorList =
-                Seq(ErrorLink(
-                    href = Some(s"${emailVerificationForm.errors.head.key}"),
-                    content = Text(messages(s"fh.${emailVerificationForm.errors.head.key}.${emailVerificationForm.
-                            errors.head.message}"))
-                )),
-                title = Text(messages("fh.generic.error"))
-            ))
-        }
-
 
         @viewHelpers.govukInput(Input(
             id = alternativeEmailKey,
@@ -65,7 +69,7 @@
             } else None,
             inputType = "email",
             label = Label(
-              isPageHeading = true,
+              isPageHeading = false,
               classes = "govuk-label--m",
               content = Text(messages("fh.emailVerification.alternativeEmail.label"))
             ),
@@ -78,10 +82,6 @@
             value = emailVerificationForm(alternativeEmailKey).value
         ))
         <input type="hidden" name="@{emailOptionKey}" value="false">
-
-    @viewHelpers.govukInsetText(InsetText(
-        content = Text(Messages("fh.emailVerification.alternativeEmail.info"))
-    ))
 
     @viewHelpers.govukButton(Button(content = Text(messages("button.continue")), inputType = Some("submit")))
 


### PR DESCRIPTION
The following changes were made:

- The error summary section has been moved above the page title (H1) for better visibility and adherence to user interface standards.
- The layout has been updated so the inset text, which provides auxiliary information about the form, is now displayed directly below the page title.
- The label on the main form has been changed from a page heading to a standard tag. This was done to better separate concerns between page-wide headings and form-specific tags.