### PR TITLE
DLS-13048 Normalise VAT numbers before DES submission

### DIFF
--- a/app/uk/gov/hmrc/fhregistrationfrontend/actions/Actions.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/actions/Actions.scala
@@ -63,13 +63,14 @@ class Actions @Inject() (
   def startVariationAction = userAction andThen new StartVariationAction(fhddsConnector)
   def enrolledUserAction = userAction andThen new EnrolledUserAction
   def journeyAction = userAction andThen new JourneyAction(journeys)
-  def pageAction(pageId: String) = journeyAction andThen new PageAction(pageId, None, journeys)
+  def pageAction(pageId: String) =
+    journeyAction andThen new PageAction(pageId, None, journeys, frontendAppConfig.vatNumberPrefixesToRemove)
 
   def newApplicationAction =
     noPendingSubmissionFilter andThen notAdminUser andThen new NewApplicationAction(fhddsConnector)
 
   def pageAction(pageId: String, sectionId: Option[String]) =
-    journeyAction andThen new PageAction(pageId, sectionId, journeys)
+    journeyAction andThen new PageAction(pageId, sectionId, journeys, frontendAppConfig.vatNumberPrefixesToRemove)
 
   def summaryAction =
     userAction andThen journeyAction andThen new SummaryAction

--- a/app/uk/gov/hmrc/fhregistrationfrontend/actions/PageAction.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/actions/PageAction.scala
@@ -27,8 +27,12 @@ import uk.gov.hmrc.fhregistrationfrontend.forms.models._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: JourneyRequest[A])
-    extends WrappedRequest[A](request) {
+class PageRequest[A](
+  val journey: JourneyNavigation,
+  p: AnyPage,
+  request: JourneyRequest[A],
+  vatNumberPrefixesToRemove: Seq[String] = VatNumber.defaultPrefixesToRemove
+) extends WrappedRequest[A](request) {
 
   def page[T]: Page[T] = p.asInstanceOf[Page[T]]
   def userId: String = request.userId
@@ -48,9 +52,15 @@ class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: Journe
   private def businessPartners(): List[BusinessPartner] =
     pageDataOpt("businessPartners").getOrElse(ListWithTrackedChanges.empty[BusinessPartner]()).values.toList
 
+  private def sanitisedVatNumber(vatNumber: Option[String]): Option[String] =
+    VatNumber.sanitisedVatNumber(vatNumber, vatNumberPrefixesToRemove)
+
+  private def sanitisedVatNumbers(vatNumbers: List[Option[String]]): List[String] =
+    vatNumbers.flatMap(sanitisedVatNumber)
+
   private[actions] def otherUsedVatNumbersFromVatNumberPage(): List[String] = {
-    val usedVatRegInCompanyOfficers = companyOfficers().flatMap(CompanyOfficer.getVatNumber)
-    val usedVatRegInBusinessPartners = businessPartners().flatMap(BusinessPartner.getVatNumber)
+    val usedVatRegInCompanyOfficers = sanitisedVatNumbers(companyOfficers().map(CompanyOfficer.getVatNumber))
+    val usedVatRegInBusinessPartners = sanitisedVatNumbers(businessPartners().map(BusinessPartner.getVatNumber))
     usedVatRegInCompanyOfficers ++ usedVatRegInBusinessPartners
   }
 
@@ -62,7 +72,7 @@ class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: Journe
       case (businessPartner, currentIndex) if currentIndex != index =>
         BusinessPartner.getVatNumber(businessPartner)
     }
-    (usedVatRegInBusinessPartners ++ List(vatNumberRegistering.flatMap(_.value))).flatten
+    sanitisedVatNumbers(usedVatRegInBusinessPartners ++ List(vatNumberRegistering.flatMap(_.value)))
   }
 
   private[actions] def otherUsedVatNumbersFromCompanyOfficersPage(
@@ -73,12 +83,12 @@ class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: Journe
       case (companyOfficer, currentIndex) if currentIndex != index =>
         CompanyOfficer.getVatNumber(companyOfficer)
     }
-    (usedVatRegInCompanyOfficers ++ List(vatNumberRegistering.flatMap(_.value))).flatten
+    sanitisedVatNumbers(usedVatRegInCompanyOfficers ++ List(vatNumberRegistering.flatMap(_.value)))
   }
 
   def isVatNumberUniqueForVatNumberPage(vatNumberPageData: VatNumber): Boolean = {
     val otherUsedVatNumbers: List[String] = otherUsedVatNumbersFromVatNumberPage()
-    vatNumberPageData.value match {
+    sanitisedVatNumber(vatNumberPageData.value) match {
       case Some(vatNumber) if otherUsedVatNumbers.contains(vatNumber) => false
       case _                                                          => true
     }
@@ -90,7 +100,7 @@ class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: Journe
   ): Boolean = {
     val otherUsedVatNumbers: List[String] =
       otherUsedVatNumbersFromBusinessPartnersPage(businessPartnersPageData, index)
-    val vatNumberOnBusinessPartner = BusinessPartner.getVatNumber(businessPartnersPageData(index))
+    val vatNumberOnBusinessPartner = sanitisedVatNumber(BusinessPartner.getVatNumber(businessPartnersPageData(index)))
     vatNumberOnBusinessPartner match {
       case Some(vatNumber) if otherUsedVatNumbers.contains(vatNumber) => false
       case _                                                          => true
@@ -103,7 +113,7 @@ class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: Journe
   ): Boolean = {
     val otherUsedVatNumbers: List[String] =
       otherUsedVatNumbersFromCompanyOfficersPage(companyOfficersPageData, index)
-    val vatNumberOnCompanyOfficer = CompanyOfficer.getVatNumber(companyOfficersPageData(index))
+    val vatNumberOnCompanyOfficer = sanitisedVatNumber(CompanyOfficer.getVatNumber(companyOfficersPageData(index)))
     vatNumberOnCompanyOfficer match {
       case Some(vatNumber) if otherUsedVatNumbers.contains(vatNumber) => false
       case _                                                          => true
@@ -112,7 +122,12 @@ class PageRequest[A](val journey: JourneyNavigation, p: AnyPage, request: Journe
 }
 
 //TODO all exceptional results need to be reviewed
-class PageAction[T, V] @Inject() (pageId: String, sectionId: Option[String], journey: Journeys)(implicit
+class PageAction[T, V] @Inject() (
+  pageId: String,
+  sectionId: Option[String],
+  journey: Journeys,
+  vatNumberPrefixesToRemove: Seq[String] = VatNumber.defaultPrefixesToRemove
+)(implicit
   errorHandler: ErrorHandler,
   val executionContext: ExecutionContext
 ) extends ActionRefiner[JourneyRequest, PageRequest] with FrontendAction {
@@ -129,7 +144,8 @@ class PageAction[T, V] @Inject() (pageId: String, sectionId: Option[String], jou
     } yield new PageRequest(
       journeyNavigation,
       pageWithSection,
-      input
+      input,
+      vatNumberPrefixesToRemove
     )
     result.value
   }

--- a/app/uk/gov/hmrc/fhregistrationfrontend/config/FrontendAppConfig.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/config/FrontendAppConfig.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.fhregistrationfrontend.config
 import javax.inject.{Inject, Singleton}
 import com.google.inject.ImplementedBy
 import play.api.Configuration
+import uk.gov.hmrc.fhregistrationfrontend.forms.models.VatNumber
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.util.Random
@@ -36,6 +37,8 @@ trait AppConfig {
   val newCompanyOfficersPagesEnabled: Boolean
 
   val isNewSessionRepositoryCacheEnabled: Boolean
+
+  val vatNumberPrefixesToRemove: Seq[String]
 
   def serviceMaxNoOfAttempts: Int
 }
@@ -83,6 +86,9 @@ class FrontendAppConfig @Inject() (
   override val newCompanyOfficersPagesEnabled: Boolean = getBoolean("company-officers-new-enabled")
 
   override val isNewSessionRepositoryCacheEnabled: Boolean = getBoolean("isNewSessionRepositoryCacheEnabled")
+  override val vatNumberPrefixesToRemove: Seq[String] =
+    configuration.getOptional[Seq[String]]("vatNumber.prefixesToRemove").getOrElse(VatNumber.defaultPrefixesToRemove)
+
   override def serviceMaxNoOfAttempts: Int = _serviceMaxNoOfAttempts
 
   // TODO [DLS-7603] - temp save4later solution remove when cookies removed from load function

--- a/app/uk/gov/hmrc/fhregistrationfrontend/controllers/DeclarationController.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/controllers/DeclarationController.scala
@@ -55,7 +55,7 @@ class DeclarationController @Inject() (
   val emailSessionKey = "declaration_email"
   val processingTimestampSessionKey = "declaration_processing_timestamp"
   val journeyTypeKey = "journey_type"
-  val formToDes: FormToDes = new FormToDesImpl()
+  val formToDes: FormToDes = new FormToDesImpl(vatNumberPrefixesToRemove = ds.appConfig.vatNumberPrefixesToRemove)
 
   import actions._
 

--- a/app/uk/gov/hmrc/fhregistrationfrontend/forms/models/VatNumber.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/forms/models/VatNumber.scala
@@ -26,9 +26,16 @@ case class VatNumber(
 object VatNumber {
   implicit val format: OFormat[VatNumber] = Json.format[VatNumber]
 
-  def sanitisedVatNumber(vatNumber: Option[String]): Option[String] =
-    vatNumber match {
-      case Some(value) if value.toLowerCase().contains("gb") => Some(value.substring(2))
-      case _                                                 => vatNumber
+  val defaultPrefixesToRemove: Seq[String] = Seq("GB")
+
+  def sanitisedVatNumber(
+    vatNumber: Option[String],
+    prefixesToRemove: Seq[String] = defaultPrefixesToRemove
+  ): Option[String] =
+    vatNumber.map { value =>
+      val valueWithoutSpaces = value.replaceAll("\\s", "")
+      prefixesToRemove
+        .find(prefix => valueWithoutSpaces.regionMatches(true, 0, prefix, 0, prefix.length))
+        .fold(valueWithoutSpaces)(prefix => valueWithoutSpaces.substring(prefix.length))
     }
 }

--- a/app/uk/gov/hmrc/fhregistrationfrontend/services/mapping/FormToDes.scala
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/services/mapping/FormToDes.scala
@@ -51,8 +51,14 @@ trait FormToDes {
   def declaration(d: Declaration): des.Declaration
 }
 
-case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Option[LocalDate] = None)
-    extends FormToDes {
+case class FormToDesImpl(
+  withModificationFlags: Boolean = false,
+  changeDate: Option[LocalDate] = None,
+  vatNumberPrefixesToRemove: Seq[String] = VatNumber.defaultPrefixesToRemove
+) extends FormToDes {
+
+  private def sanitisedVatNumber(vatNumber: Option[String]): Option[String] =
+    VatNumber.sanitisedVatNumber(vatNumber, vatNumberPrefixesToRemove)
 
   def withModificationFlags(withModificationFlags: Boolean = false, changeDate: Option[LocalDate]): FormToDes =
     this.copy(withModificationFlags = true, changeDate = changeDate)
@@ -223,7 +229,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
   ): SoleProprietorIdentification =
     SoleProprietorIdentification(
       st.nationalInsuranceNumber.value,
-      VatNumber.sanitisedVatNumber(st.vatNumber.value),
+      sanitisedVatNumber(st.vatNumber.value),
       bpr.utr
     )
 
@@ -231,7 +237,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
     des.NonProprietor(
       tradingName.value,
       des.NonProprietorIdentification(
-        VatNumber.sanitisedVatNumber(vatNumber.value),
+        sanitisedVatNumber(vatNumber.value),
         bpr.utr
       )
     )
@@ -363,7 +369,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
               Name(firstName = s.firstName, None, lastName = s.lastName),
               nino = s.nino,
               identification = PartnerIdentification(
-                vatRegistrationNumber = s.vat,
+                vatRegistrationNumber = sanitisedVatNumber(s.vat),
                 uniqueTaxpayerReference = s.uniqueTaxpayerReference
               ),
               tradingName = s.tradeName
@@ -377,7 +383,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
             partnerTypeDetail = PartnershipOrUnIncorporatedBodyPartnerType(
               CompanyName(companyName = Some(p.partnershipName), tradingName = p.tradeName),
               identification = PartnerIdentification(
-                vatRegistrationNumber = p.vat,
+                vatRegistrationNumber = sanitisedVatNumber(p.vat),
                 uniqueTaxpayerReference = p.uniqueTaxpayerReference
               )
             ),
@@ -390,7 +396,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
             partnerTypeDetail = LimitedLiabilityPartnershipType(
               CompanyName(companyName = Some(l.limitedLiabilityPartnershipName), tradingName = l.tradeName),
               identification = PartnerIdentification(
-                vatRegistrationNumber = l.vat,
+                vatRegistrationNumber = sanitisedVatNumber(l.vat),
                 uniqueTaxpayerReference = l.uniqueTaxpayerReference
               ),
               incorporationDetails = IncorporationDetail(
@@ -407,7 +413,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
             partnerTypeDetail = LimitedLiabilityPartnershipType(
               CompanyName(companyName = Some(c.companyName), tradingName = c.tradeName),
               identification = PartnerIdentification(
-                vatRegistrationNumber = c.vat,
+                vatRegistrationNumber = sanitisedVatNumber(c.vat),
                 uniqueTaxpayerReference = c.uniqueTaxpayerReference
               ),
               incorporationDetails = IncorporationDetail(
@@ -424,7 +430,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
             partnerTypeDetail = PartnershipOrUnIncorporatedBodyPartnerType(
               CompanyName(companyName = Some(u.unincorporatedBodyName), tradingName = u.tradeName),
               identification = PartnerIdentification(
-                vatRegistrationNumber = u.vat,
+                vatRegistrationNumber = sanitisedVatNumber(u.vat),
                 uniqueTaxpayerReference = u.uniqueTaxpayerReference
               )
             ),
@@ -446,7 +452,7 @@ case class FormToDesImpl(withModificationFlags: Boolean = false, changeDate: Opt
     des.CompanyAsOfficial(
       role,
       des.CompanyName(Some(companyName), None),
-      des.CompanyIdentification(c.vat, None, c.crn),
+      des.CompanyIdentification(sanitisedVatNumber(c.vat), None, c.crn),
       modification
     )
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,6 +17,10 @@ include "frontend.conf"
 appName = "fh-registration-frontend"
 play.http.router = prod.Routes
 
+vatNumber {
+  prefixesToRemove = ["GB"]
+}
+
 play {
 
   modules {
@@ -178,4 +182,3 @@ tracking-consent-frontend {
 business-partners-new-enabled = true
 company-officers-new-enabled = true
 isNewSessionRepositoryCacheEnabled = false
-

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,7 +11,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"                %% s"bootstrap-frontend-$playVersion"            % bootstrapVersion,
-    "uk.gov.hmrc"                %% s"play-frontend-hmrc-$playVersion"            % "13.3.0",
+    "uk.gov.hmrc"                %% s"play-frontend-hmrc-$playVersion"            % "13.5.0",
     "uk.gov.hmrc"                %% s"play-partials-$playVersion"                 % "10.2.0",
     "uk.gov.hmrc"                %% s"play-hmrc-api-$playVersion"                 % "8.3.0",
     "uk.gov.hmrc"                %% s"http-caching-client-$playVersion"           % "12.2.0",

--- a/test/uk/gov/hmrc/fhregistrationfrontend/actions/PageActionSpec.scala
+++ b/test/uk/gov/hmrc/fhregistrationfrontend/actions/PageActionSpec.scala
@@ -326,6 +326,27 @@ class PageActionSpec extends ActionSpecBase with JourneyRequestBuilder {
       refined.isVatNumberUniqueForVatNumberPage(nonUniqueVatNumber) shouldBe false
     }
 
+    "Check if prefixed vat number is not unique when unprefixed value is already used" in {
+      val prefixedNonUniqueVatNumber = FormTestData.vatNumber.copy(value = Some("GB423456789"))
+      val seqPages = journeys.partnershipPages map { page =>
+        page.id match {
+          case businessPartnersPage.id =>
+            page.asInstanceOf[RepeatingPage[BusinessPartner]] `withData` FormTestData.partners
+          case vatNumberPage.id => page.asInstanceOf[Page[VatNumber]] `withData` prefixedNonUniqueVatNumber
+          case _                => page
+        }
+      }
+
+      val request = journeyRequest(journeyPages = new JourneyPages(seqPages))
+      val action = new PageAction(vatNumberPage.id, None, journeys)(
+        using StubbedErrorHandler,
+        scala.concurrent.ExecutionContext.Implicits.global
+      )
+
+      val refined = refinedRequest(action, request)
+      refined.isVatNumberUniqueForVatNumberPage(prefixedNonUniqueVatNumber) shouldBe false
+    }
+
     "Check if vat number unique in business partners when passed a first business partner with unique vat number - business partnership journey" in {
       val businessPartnerWithNonUniqueVatNumber =
         FormTestData.businessPartnerSoleProprietorWithVatNumber(FormTestData.vatNumber.value)
@@ -376,6 +397,33 @@ class PageActionSpec extends ActionSpecBase with JourneyRequestBuilder {
       val refined = refinedRequest(action, request)
       refined.isVatNumberUniqueForBusinessPartner(
         businessPartnersWithNonUniqueFirstVatNumber.values.toList,
+        index = 0
+      ) shouldBe false
+    }
+
+    "Check if prefixed vat number in business partners is not unique when applicant vat number is unprefixed" in {
+      val businessPartnerWithPrefixedVatNumber =
+        FormTestData.businessPartnerSoleProprietorWithVatNumber(Some("GB123456789"))
+      val businessPartnersWithPrefixedVatNumber =
+        FormTestData.partners.updated(0, businessPartnerWithPrefixedVatNumber)
+      val seqPages = journeys.partnershipPages map { page =>
+        page.id match {
+          case businessPartnersPage.id =>
+            page.asInstanceOf[RepeatingPage[BusinessPartner]] `withData` businessPartnersWithPrefixedVatNumber
+          case vatNumberPage.id => page.asInstanceOf[Page[VatNumber]] `withData` FormTestData.vatNumber
+          case _                => page
+        }
+      }
+
+      val request = journeyRequest(journeyPages = new JourneyPages(seqPages))
+      val action = new PageAction(businessPartnersPage.id, None, journeys)(
+        using StubbedErrorHandler,
+        scala.concurrent.ExecutionContext.Implicits.global
+      )
+
+      val refined = refinedRequest(action, request)
+      refined.isVatNumberUniqueForBusinessPartner(
+        businessPartnersWithPrefixedVatNumber.values.toList,
         index = 0
       ) shouldBe false
     }
@@ -484,6 +532,33 @@ class PageActionSpec extends ActionSpecBase with JourneyRequestBuilder {
       val refined = refinedRequest(action, request)
       refined.isVatNumberUniqueForCompanyOfficer(
         companyOfficersWithNonUniqueFirstVatNumber.values.toList,
+        index = 0
+      ) shouldBe false
+    }
+
+    "Check if prefixed vat number in company officers is not unique when applicant vat number is unprefixed" in {
+      val companyOfficerWithPrefixedVatNumber =
+        FormTestData.companyOfficerCompanyWithVatNumber(Some("GB123456789"))
+      val companyOfficersWithPrefixedVatNumber =
+        FormTestData.companyOfficers.updated(0, companyOfficerWithPrefixedVatNumber)
+      val seqPages = journeys.limitedCompanyPages map { page =>
+        page.id match {
+          case companyOfficersPage.id =>
+            page.asInstanceOf[RepeatingPage[CompanyOfficer]] `withData` companyOfficersWithPrefixedVatNumber
+          case vatNumberPage.id => page.asInstanceOf[Page[VatNumber]] `withData` FormTestData.vatNumber
+          case _                => page
+        }
+      }
+
+      val request = journeyRequest(journeyPages = new JourneyPages(seqPages))
+      val action = new PageAction(companyOfficersPage.id, None, journeys)(
+        using StubbedErrorHandler,
+        scala.concurrent.ExecutionContext.Implicits.global
+      )
+
+      val refined = refinedRequest(action, request)
+      refined.isVatNumberUniqueForCompanyOfficer(
+        companyOfficersWithPrefixedVatNumber.values.toList,
         index = 0
       ) shouldBe false
     }

--- a/test/uk/gov/hmrc/fhregistrationfrontend/controllers/DeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/fhregistrationfrontend/controllers/DeclarationControllerSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.fhregistrationfrontend.config.{AppConfig, ErrorHandler}
 import uk.gov.hmrc.fhregistrationfrontend.connectors.FhddsConnector
 import uk.gov.hmrc.fhregistrationfrontend.forms.definitions.DeclarationForm.{defaultEmailKey, fullNameKey, jobTitleKey, usingDefaultEmailKey}
 import uk.gov.hmrc.fhregistrationfrontend.forms.journey.{CachedJourneyState, JourneyPages, JourneyType, Journeys, Page}
-import uk.gov.hmrc.fhregistrationfrontend.forms.models.BusinessType
+import uk.gov.hmrc.fhregistrationfrontend.forms.models.{BusinessType, VatNumber}
 import uk.gov.hmrc.fhregistrationfrontend.models.fhregistration.SubmissionOutcome.ActiveSubscription
 import uk.gov.hmrc.fhregistrationfrontend.services.mapping.DesToForm
 import uk.gov.hmrc.fhregistrationfrontend.services.{Save4LaterService, SummaryConfirmationLocalService}
@@ -61,10 +61,12 @@ class DeclarationControllerSpec extends PlaySpec with MockitoSugar with ScalaFut
   private val controllerMessagesApi: MessagesApi = new DefaultMessagesApi(
     Map("en" -> Map("fh.declaration.activeSubscription.error" -> activeSubscriptionMessage))
   )
+  private val mockAppConfig = mock[AppConfig]
+  when(mockAppConfig.vatNumberPrefixesToRemove).thenReturn(VatNumber.defaultPrefixesToRemove)
 
   private val commonDependencies = new CommonPlayDependencies(
     Configuration.empty,
-    mock[AppConfig],
+    mockAppConfig,
     Environment.simple(),
     controllerMessagesApi,
     mock[ErrorHandler],

--- a/test/uk/gov/hmrc/fhregistrationfrontend/services/mapping/FormToDesSpecs.scala
+++ b/test/uk/gov/hmrc/fhregistrationfrontend/services/mapping/FormToDesSpecs.scala
@@ -22,8 +22,10 @@ import com.github.fge.jsonschema.core.report.{ListReportProvider, LogLevel, Proc
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import org.apache.commons.io.FilenameUtils
 import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.fhregistrationfrontend.forms.models._
+import uk.gov.hmrc.fhregistrationfrontend.models.businessPartners.BusinessPartnerType
 import uk.gov.hmrc.fhregistrationfrontend.models.businessregistration.BusinessRegistrationDetails
-import uk.gov.hmrc.fhregistrationfrontend.models.des.{SubScriptionCreate, Subscription}
+import uk.gov.hmrc.fhregistrationfrontend.models.des.{CompanyAsOfficial, IndividualPartnerType, LimitedLiabilityPartnershipType, PartnershipOrUnIncorporatedBodyPartnerType, SoleProprietorPartnerType, SubScriptionCreate, Subscription}
 import uk.gov.hmrc.fhregistrationfrontend.services.mapping.data._
 import uk.gov.hmrc.fhregistrationfrontend.util.UnitSpec
 
@@ -229,6 +231,37 @@ class FormToDesSpecs extends UnitSpec {
     validatesFor(submission, "fhdds-limited-company-large-uk", "limited-company")
   }
 
+  "Normalise prefixed VAT numbers for limited company DES submission" in {
+    val application = LtdLargeUk.application()
+    val prefixedApplication = application.copy(
+      vatNumber = VatNumber(true, Some("GB123456789")),
+      companyOfficers = application.companyOfficers.updated(
+        2,
+        CompanyOfficer(
+          CompanyOfficerType.Company,
+          CompanyOfficerCompany("Some Company", hasVat = true, Some("GB987654321"), None, "Company Secretary")
+        )
+      )
+    )
+
+    val submission = SubScriptionCreate(
+      "Create",
+      service.limitedCompanySubmission(
+        brd("business-registration-details-limited-company.json"),
+        LtdLargeUk.verifiedEmail,
+        prefixedApplication,
+        LtdLargeUk.declaration
+      ),
+      None
+    )
+
+    submission.subScriptionCreate.businessDetail.nonProprietor.flatMap(
+      _.identification.vatRegistrationNumber
+    ) shouldBe Some("123456789")
+    companyOfficialVatNumbers(submission.subScriptionCreate) should contain("987654321")
+    validateAgainstSchema(JsonLoader.fromString(Json.toJson(submission).toString)).isSuccess shouldBe true
+  }
+
   "Create a correct json for fhdds-limited-company-large-uk-updated" in {
     val submission = SubScriptionCreate(
       "Update",
@@ -296,7 +329,98 @@ class FormToDesSpecs extends UnitSpec {
 
       validatesFor(submission, "partnership-large-int", "partnership")
     }
+
+    "Normalise prefixed VAT numbers for business partners before DES submission" in {
+      val application = PartnershipLargeInt.application()
+      val prefixedBusinessPartners = application.businessPartners
+        .updated(
+          1,
+          BusinessPartner(
+            BusinessPartnerType.SoleProprietor,
+            BusinessPartnerSoleProprietor(
+              "ms sole",
+              "trader",
+              hasTradeName = true,
+              Some("dodgy sole trader"),
+              hasNino = true,
+              Some("AA123231"),
+              hasVat = true,
+              Some("GB223456789"),
+              None,
+              Address("sole line one", None, None, Some("sole town"), "AA13 1AA", None, None)
+            )
+          )
+        )
+        .updated(
+          2,
+          BusinessPartner(
+            BusinessPartnerType.LimitedLiabilityPartnership,
+            BusinessPartnerLimitedLiabilityPartnership(
+              "fulfilment llp",
+              hasTradeName = true,
+              Some("dodgy llp"),
+              "SC123456",
+              hasVat = true,
+              Some("GB323456789"),
+              None,
+              Address(
+                "llp line one",
+                Some("llp line two"),
+                Some("llp line three"),
+                Some("llp town"),
+                "AA14 1AA",
+                None,
+                None
+              )
+            )
+          )
+        )
+
+      val submission = SubScriptionCreate(
+        "Create",
+        service.partnership(
+          brd("business-registration-details-partnership.json"),
+          PartnershipLargeInt.verifiedEmail,
+          application.copy(
+            vatNumber = VatNumber(true, Some("GB123456789")),
+            businessPartners = prefixedBusinessPartners
+          ),
+          PartnershipLargeInt.declaration
+        ),
+        None
+      )
+
+      submission.subScriptionCreate.businessDetail.nonProprietor.flatMap(
+        _.identification.vatRegistrationNumber
+      ) shouldBe Some("123456789")
+      partnerVatNumbers(submission.subScriptionCreate) should contain allOf ("223456789", "323456789")
+      validateAgainstSchema(JsonLoader.fromString(Json.toJson(submission).toString)).isSuccess shouldBe true
+    }
   }
+
+  private def companyOfficialVatNumbers(subscription: Subscription): List[String] =
+    subscription.additionalBusinessInformation.partnerCorporateBody
+      .flatMap(_.companyOfficials)
+      .toList
+      .flatten
+      .collect { case company: CompanyAsOfficial =>
+        company.identification.vatRegistrationNumber
+      }
+      .flatten
+
+  private def partnerVatNumbers(subscription: Subscription): List[String] =
+    subscription.businessDetail.partnership
+      .map(_.partnerDetails)
+      .getOrElse(Nil)
+      .flatMap {
+        _.partnerTypeDetail match {
+          case partnerType: SoleProprietorPartnerType       => partnerType.identification.vatRegistrationNumber
+          case partnerType: LimitedLiabilityPartnershipType => partnerType.identification.vatRegistrationNumber
+          case partnerType: PartnershipOrUnIncorporatedBodyPartnerType =>
+            partnerType.identification.vatRegistrationNumber
+          case _: IndividualPartnerType => None
+        }
+      }
 
   def validatesFor(subscrtiptionCreate: SubScriptionCreate, file: String, entityPath: String) = {
 


### PR DESCRIPTION
Normalise VAT registration numbers consistently before backend submission and duplicate checks.
<img width="1735" height="341" alt="image" src="https://github.com/user-attachments/assets/6554db2e-bb98-49e3-961b-d67e411608ed" />
