### PR TITLE
DLS-13328 [FHDDS] Update Submission Page With GOV.UK Details and Summary List Components

### DIFF
--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/acknowledgement_page.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/acknowledgement_page.scala.html
@@ -30,11 +30,6 @@
 
 @(date: Date, email:String, printableSummary: Html, mode: Mode)(implicit request: Request[?], messages: Messages, config: AppConfig)
 
-@pageHeadBlock = {
-  <link href="@routes.Assets.at("stylesheets/fhdds-govuk.css")" media="all" rel="stylesheet" type="text/css">
-}
-
-
 @title1 = @{
   Messages(s"fh.ack.$mode.title")
 }
@@ -43,7 +38,7 @@
   formatDate(date)
 }
 
-@layout(title = title1, pageHeadBlock = Some(pageHeadBlock)) {
+@layout(title = title1) {
 
     @viewHelpers.govukPanel(Panel(
         title = Text(title1),
@@ -107,8 +102,15 @@
         <a class="govuk-link" href="@config.exitSurveyUrl">@Messages("fh.survey_link_text")@Messages("fh.survey_hint")</a>
       </p>
 
-      <div class="fhdds-print-only govuk-body">
-        @printableSummary
-      </div>
+      <details class="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            @Messages("fh.ack.application_summary")
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          @printableSummary
+        </div>
+      </details>
 
 }

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryAddress.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryAddress.scala.html
@@ -24,15 +24,12 @@
     case _ => ""
   }
 }
-<div>
-  <dt class="cya-question">@if(params.label.nonEmpty){ @params.label }</dt>
-  <dd class="cya-answer">@{params.value}</dd>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">@if(params.label.nonEmpty){ @params.label }</dt>
+  <dd class="govuk-summary-list__value">@{params.value}</dd>
   @if(params.changeLink.nonEmpty) {
-    <dd class="cya-change@{linkClass}">
-      <a class="hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.load(params.changeLink.get)}">Change<span class="visuallyhidden"> @{params.label}</span></a>
+    <dd class="govuk-summary-list__actions@{linkClass}">
+      <a class="govuk-link hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.load(params.changeLink.get)}">Change<span class="govuk-visually-hidden"> @{params.label}</span></a>
     </dd>
-  }
-  @if(params.groupRow == GroupRow.Bottom) {
-    <dd></dd>
   }
 </div>

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryRepeatingAddress.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryRepeatingAddress.scala.html
@@ -15,12 +15,12 @@
  *@
 
 @(heading:String, address:Html, changeLink: Option[String] = None, section: String)
-<div>
-  <dt class="cya-question">@{heading}</dt>
-  <dd class="cya-answer">@address</dd>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">@{heading}</dt>
+  <dd class="govuk-summary-list__value">@address</dd>
   @if(changeLink.nonEmpty){
-    <dd class="cya-change group-head">
-        <a href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.loadWithSection(changeLink.get, section)}">Change<span class="visuallyhidden"> @heading</span></a>
+    <dd class="govuk-summary-list__actions group-head">
+        <a class="govuk-link" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.loadWithSection(changeLink.get, section)}">Change<span class="govuk-visually-hidden"> @heading</span></a>
     </dd>
   }
 </div>

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryRepeatingHead.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryRepeatingHead.scala.html
@@ -15,12 +15,12 @@
  *@
 
 @(heading:String, changeLink: Option[String] = None, section: String)
-<div>
-  <dt class="cya-question">@heading</dt>
-  <dd class="cya-answer"></dd>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">@heading</dt>
+  <dd class="govuk-summary-list__value"></dd>
   @if(changeLink.nonEmpty){
-    <dd class="cya-change group-head">
-      <a class="hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.loadWithSection(changeLink.get, section)}">Change<span class="visuallyhidden"> @heading</span></a>
+    <dd class="govuk-summary-list__actions group-head">
+      <a class="govuk-link hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.loadWithSection(changeLink.get, section)}">Change<span class="govuk-visually-hidden"> @heading</span></a>
     </dd>
   }
 </div>

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryRow.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummaryRow.scala.html
@@ -32,15 +32,12 @@
   }
 
 }
-<div>
-  <dt class="cya-question">@if(params.label.nonEmpty){ @params.label }</dt>
-  <dd class="cya-answer">@if(params.value.nonEmpty){ @params.value }</dd>
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">@if(params.label.nonEmpty){ @params.label }</dt>
+  <dd class="govuk-summary-list__value">@if(params.value.nonEmpty){ @params.value }</dd>
   @if(params.changeLink.nonEmpty){
-    <dd class="cya-change@{linkClass}">
-      <a class="hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.load(params.changeLink.get)}">Change<span class="visuallyhidden"> @changeLinkText</span></a>
+    <dd class="govuk-summary-list__actions@{linkClass}">
+      <a class="govuk-link hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.FormPageController.load(params.changeLink.get)}">Change<span class="govuk-visually-hidden"> @changeLinkText</span></a>
     </dd>
-  }
-  @if(params.groupRow == GroupRow.Bottom) {
-    <dd></dd>
   }
 </div>

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummarySectionHead.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/helpers/SummarySectionHead.scala.html
@@ -16,6 +16,6 @@
 
 @(heading:String)
 
-<h2 class="heading-medium">
+<h3 class="govuk-heading-m">
  @{heading}
-</h2>
+</h3>

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/ContactPerson.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/ContactPerson.scala.html
@@ -33,7 +33,7 @@
 }
 
 @SummarySectionHead(heading = Messages("fh.contactPerson.title"))
-<dl class="govuk-check-your-answers cya-questions-long">
+<dl class="govuk-summary-list">
     @SummaryRow(
         SummaryRowParams.ofString(
             Some(Messages("fh.generic.name")),

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/EmailAddress.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/EmailAddress.scala.html
@@ -23,15 +23,15 @@
 
 @SummarySectionHead(heading = Messages("fh.summary.email.title"))
 
-<dl class="govuk-check-your-answers cya-questions-long">
-    <div>
-        <dt class="cya-question">@Messages("fh.summary.email.label")</dt>
-        <dd class="cya-answer">@verifiedEmail</dd>
-        <dd class="cya-change">
+<dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">@Messages("fh.summary.email.label")</dt>
+        <dd class="govuk-summary-list__value">@verifiedEmail</dd>
         @if(Mode.isEditable(mode)){
-            <a class="hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.EmailVerificationController.emailEdit}">Change<span class="visuallyhidden"> @Messages("fh.summary.email.title")</span></a>
+            <dd class="govuk-summary-list__actions">
+                <a class="govuk-link hidden-print" href="@{uk.gov.hmrc.fhregistrationfrontend.controllers.routes.EmailVerificationController.emailEdit}">Change<span class="govuk-visually-hidden"> @Messages("fh.summary.email.title")</span></a>
+            </dd>
         }
-        </dd>
     </div>
 
 </dl>

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/MainBusinessAddress.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/MainBusinessAddress.scala.html
@@ -37,7 +37,7 @@
 
 @SummarySectionHead(heading = Messages("fh.main_business_address.title"))
 
-<dl class="govuk-check-your-answers cya-questions-long">
+<dl class="govuk-summary-list">
 
     @SummaryRow(
         SummaryRowParams.ofString(

--- a/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/SummaryPrintable.scala.html
+++ b/app/uk/gov/hmrc/fhregistrationfrontend/views/summary/SummaryPrintable.scala.html
@@ -29,7 +29,7 @@
           ContactPerson(limitedCompanyApplication.contactPerson, bpr, ReadOnlyApplication).toString() +
           MainBusinessAddress(limitedCompanyApplication.mainBusinessAddress, ReadOnlyApplication).toString() +
           SummarySectionHead(heading = Messages("fh.summary.businessDetails")).toString() +
-          "<dl class=\"govuk-check-your-answers cya-questions-long\">" +
+          "<dl class=\"govuk-summary-list\">" +
           CompanyRegistrationNumber(limitedCompanyApplication.companyRegistrationNumber, ReadOnlyApplication).toString() +
           DateOfIncorporation(limitedCompanyApplication.dateOfIncorporation, ReadOnlyApplication).toString() +
           TradingName(limitedCompanyApplication.tradingName, ReadOnlyApplication).toString() +
@@ -37,7 +37,7 @@
           CompanyOfficers(limitedCompanyApplication.companyOfficers, ReadOnlyApplication).toString() +
           "</dl>" +
           SummarySectionHead(heading = Messages("fh.summary.businessActivities")).toString() +
-          "<dl class=\"govuk-check-your-answers cya-questions-long\">" +
+          "<dl class=\"govuk-summary-list\">" +
           BusinessStatus(limitedCompanyApplication.businessStatus, ReadOnlyApplication).toString() +
           ImportingActivities(limitedCompanyApplication.importingActivities, ReadOnlyApplication).toString() +
           BusinessCustomers(limitedCompanyApplication.businessCustomers, ReadOnlyApplication).toString() +
@@ -51,13 +51,13 @@
             ContactPerson(soleProprietorApplication.contactPerson, bpr, ReadOnlyApplication).toString() +
             MainBusinessAddress(soleProprietorApplication.mainBusinessAddress, ReadOnlyApplication).toString() +
             SummarySectionHead(heading = Messages("fh.summary.businessDetails")).toString() +
-            "<dl class=\"govuk-check-your-answers cya-questions-long\">" +
+            "<dl class=\"govuk-summary-list\">" +
             NationalInsurance(soleProprietorApplication.nationalInsuranceNumber, ReadOnlyApplication).toString() +
             TradingName(soleProprietorApplication.tradingName, ReadOnlyApplication).toString() +
             VATRegistrationNumber(soleProprietorApplication.vatNumber, ReadOnlyApplication).toString() +
             "</dl>" +
             SummarySectionHead(heading = Messages("fh.summary.businessActivities")).toString() +
-            "<dl class=\"govuk-check-your-answers cya-questions-long\">" +
+            "<dl class=\"govuk-summary-list\">" +
             BusinessStatus(soleProprietorApplication.businessStatus, ReadOnlyApplication).toString() +
             ImportingActivities(soleProprietorApplication.importingActivities, ReadOnlyApplication).toString() +
             BusinessCustomers(soleProprietorApplication.businessCustomers, ReadOnlyApplication).toString() +
@@ -71,13 +71,13 @@
             ContactPerson(partnershipApplication.contactPerson, bpr, ReadOnlyApplication).toString() +
             MainBusinessAddress(partnershipApplication.mainBusinessAddress, ReadOnlyApplication).toString() +
             SummarySectionHead(heading = Messages("fh.summary.businessDetails")).toString() +
-            "<dl class=\"govuk-check-your-answers cya-questions-long\">" +
+            "<dl class=\"govuk-summary-list\">" +
             TradingName(partnershipApplication.tradingName, ReadOnlyApplication).toString() +
             VATRegistrationNumber(partnershipApplication.vatNumber, ReadOnlyApplication).toString() +
             BusinessPartners(partnershipApplication.businessPartners, ReadOnlyApplication).toString() +
             "</dl>" +
             SummarySectionHead(heading = Messages("fh.summary.businessActivities")).toString() +
-            "<dl class=\"govuk-check-your-answers cya-questions-long\">" +
+            "<dl class=\"govuk-summary-list\">" +
             BusinessStatus(partnershipApplication.businessStatus, ReadOnlyApplication).toString() +
             ImportingActivities(partnershipApplication.importingActivities, ReadOnlyApplication).toString() +
             BusinessCustomers(partnershipApplication.businessCustomers, ReadOnlyApplication).toString() +

--- a/conf/messages
+++ b/conf/messages
@@ -1022,6 +1022,7 @@ fh.delete_confirmation_section.delete=Delete {0}
 # - Acknowledgement Page
 #============================================================
 fh.ack.application_submitted=Application submitted
+fh.ack.application_summary=View your application summary
 fh.ack.confirmation_email_sent=We will send a confirmation email to
 fh.ack.what_happens_next=What happens next
 fh.ack.what_happens_next_1=We will review your application. We may get in touch with your contact person to discuss your application

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val playVersion = "play-30"
   val bootstrapVersion = "10.7.0"
-  val hmrcMongoVersion = "2.12.0"
+  val hmrcMongoVersion = "2.13.0"
   val monocleVersion = "3.3.0"
 
   val compile: Seq[ModuleID] = Seq(

--- a/public/stylesheets/fhdds-govuk.css
+++ b/public/stylesheets/fhdds-govuk.css
@@ -1,13 +1,3 @@
-.fhdds-print-only {
-  display: none;
-}
-
-@media print {
-  .fhdds-print-only {
-    display: block;
-  }
-}
-
 .autocomplete__input.govuk-input--error {
   border-color: #d4351c;
 }

--- a/test/uk/gov/hmrc/fhregistrationfrontend/views/AcknowledgementPageViewSpec.scala
+++ b/test/uk/gov/hmrc/fhregistrationfrontend/views/AcknowledgementPageViewSpec.scala
@@ -46,5 +46,31 @@ class AcknowledgementPageViewSpec extends ViewSpecHelper {
       document.html().contains("icon-file-download") mustBe false
       document.html().contains("js-show") mustBe false
     }
+
+    "render the application summary inside a collapsed details component" in {
+      val html = acknowledgementPage(
+        new Date(),
+        "user@test.com",
+        Html(
+          """<dl class="govuk-summary-list"><div class="govuk-summary-list__row"><dt class="govuk-summary-list__key">Email address</dt><dd class="govuk-summary-list__value">user@test.com</dd></div></dl>"""
+        ),
+        New
+      )(using request, Messages, appConfig)
+
+      val document = doc(html)
+      val details = document.select("details.govuk-details").first()
+
+      details.hasAttr("open") mustBe false
+      details.select(".govuk-details__summary-text").text() mustBe "View your application summary"
+      details.select(".govuk-summary-list").size() mustBe 1
+      details.select(".govuk-summary-list__row").size() mustBe 1
+
+      document.html().contains("fhdds-print-only") mustBe false
+      document.html().contains("govuk-check-your-answers") mustBe false
+      document.html().contains("cya-question") mustBe false
+      document.html().contains("cya-answer") mustBe false
+      document.html().contains("cya-change") mustBe false
+      document.select("details a").size() mustBe 0
+    }
   }
 }


### PR DESCRIPTION


The summary page now uses modern GOV.UK summary-list styling, while the submitted page shows the same application summary inside a collapsed “View your application summary” details section, with no change links.

<img width="2260" height="288" alt="image" src="https://github.com/user-attachments/assets/41e2897d-af7d-4c28-ac0e-6900ae75f066" />
